### PR TITLE
Pipenv File & Unused Imports

### DIFF
--- a/05_prediction/src/predict.py
+++ b/05_prediction/src/predict.py
@@ -8,12 +8,9 @@ import json
 import cv2
 import math
 import re
-import os
 import itertools
 import enum
-import scipy
 import PIL.Image
-import collections
 import logging
 
 from pathlib import Path

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,20 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+tensorflow = "==1.15.2"
+# Used by tensorflow and due to the following:
+# https://github.com/tensorflow/tensorflow/issues/44467
+h5py = "<3.0.0"
+opencv-python = ">=4.4"
+tqdm = "*"
+keras = "~=2.3.1"
+segmentation-models = "~=1.0.1"
+
+[requires]
+python_version = "3.7"
+


### PR DESCRIPTION
This PR removes unused imports in the predict module and adds a Pipefile for the entire package that reflects the package versions that where used to train and build the models. 

This should help resolve issues such as those described in this ticket here:
https://github.com/poke1024/bbz-segment/issues/2

In addition, take note of the `h5py` package version specification in the `Pipefile` this is due to the following issue: https://github.com/tensorflow/tensorflow/issues/44467

Users can now utilize Pipenv and simply the following commands to start working on the package:

`pipenv update`
`pipenv shell`
`python [desired_module]`

Also of importance is the python version, `tensorflow==1.15` does not support python 3.8, hence the pinning of the python version in the `Pipefile`.